### PR TITLE
Server code is now using TypedError from error package and the reason "slug" / language agnostic unique string is now on the "type" field

### DIFF
--- a/Jetstream/Functions.swift
+++ b/Jetstream/Functions.swift
@@ -58,8 +58,8 @@ func errorFromDictionary(code: ErrorCode, error: [NSString: AnyObject]) -> NSErr
     if let errorMessage = error["message"] as? String {
         userInfo[NSLocalizedDescriptionKey] = errorMessage
     }
-    if let errorSlug = error["slug"] as? String {
-        userInfo[NSLocalizedFailureReasonErrorKey] = errorSlug
+    if let errorType = error["type"] as? String {
+        userInfo[NSLocalizedFailureReasonErrorKey] = errorType
     }
     return errorWithUserInfo(code, userInfo)
 }

--- a/JetstreamTests/TransactionTests.swift
+++ b/JetstreamTests/TransactionTests.swift
@@ -182,8 +182,7 @@ class TransactionTests: XCTestCase {
             "fragmentReplies": [
                 [String: AnyObject](),
                 ["error": [
-                    "code": 1,
-                    "slug": "invalid-type",
+                    "type": "invalid-type",
                     "message": "Invalid type for property 'name'"
                     ]
                 ]


### PR DESCRIPTION
This is to match the server refactor at https://github.com/uber/jetstream/pull/14

cc @artman @bolsinga 
