### PR TITLE
Don't send superfluous add fragments

### DIFF
--- a/Jetstream.xcodeproj/project.pbxproj
+++ b/Jetstream.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		72126CAE1A311F620006CD29 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72126CAD1A311F620006CD29 /* WebSocket.swift */; };
 		72126CAF1A3121410006CD29 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72126CAD1A311F620006CD29 /* WebSocket.swift */; };
 		72126CB01A3121410006CD29 /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72126CAB1A311F480006CD29 /* Signal.swift */; };
-		7220026C1A08362B00C6DCDD /* ChangeSetQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7216634E19F83FD3007704D2 /* ChangeSetQueueTests.swift */; };
 		72226A7B1A0C0792008EE330 /* Jetstream-bridging-header.h in Headers */ = {isa = PBXBuildFile; fileRef = 72226A791A0C0748008EE330 /* Jetstream-bridging-header.h */; };
 		722555FC19F819D90016D8F8 /* Jetstream.h in Headers */ = {isa = PBXBuildFile; fileRef = 722555FB19F819D90016D8F8 /* Jetstream.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7225560219F819DA0016D8F8 /* Jetstream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 722555F619F819D90016D8F8 /* Jetstream.framework */; };
@@ -60,21 +59,11 @@
 		7225568819F81B430016D8F8 /* ChangeSetQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225565A19F81B040016D8F8 /* ChangeSetQueue.swift */; };
 		7225568919F81B430016D8F8 /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225565B19F81B040016D8F8 /* Transport.swift */; };
 		7225568A19F81B430016D8F8 /* WebsocketTransportAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225565C19F81B040016D8F8 /* WebsocketTransportAdapter.swift */; };
+		722F9AC41A43893A00A2369A /* ChangeSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561E19F81AA10016D8F8 /* ChangeSetTests.swift */; };
 		723A39791A042A1E00FD47A0 /* ScopeSyncReplyMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723A39781A042A1E00FD47A0 /* ScopeSyncReplyMessage.swift */; };
 		723A397F1A0446CB00FD47A0 /* ScopeFetchReplyMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723A397E1A0446CB00FD47A0 /* ScopeFetchReplyMessage.swift */; };
 		723A39801A07F8E900FD47A0 /* ScopeFetchReplyMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723A397E1A0446CB00FD47A0 /* ScopeFetchReplyMessage.swift */; };
 		723A39811A07F8E900FD47A0 /* ScopeSyncReplyMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723A39781A042A1E00FD47A0 /* ScopeSyncReplyMessage.swift */; };
-		724F58911A083725003A95A3 /* ChangeSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561E19F81AA10016D8F8 /* ChangeSetTests.swift */; };
-		724F58921A083725003A95A3 /* DependencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561419F81AA10016D8F8 /* DependencyTests.swift */; };
-		724F58931A083725003A95A3 /* ImmediatePropertyListeners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561619F81AA10016D8F8 /* ImmediatePropertyListeners.swift */; };
-		724F58941A083725003A95A3 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561719F81AA10016D8F8 /* ModelTests.swift */; };
-		724F58951A083725003A95A3 /* PropertyListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561819F81AA10016D8F8 /* PropertyListenerTests.swift */; };
-		724F58961A083725003A95A3 /* ScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561919F81AA10016D8F8 /* ScopeTests.swift */; };
-		724F58971A083725003A95A3 /* StateMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561A19F81AA10016D8F8 /* StateMessageTests.swift */; };
-		724F58981A083725003A95A3 /* SyncFragmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561B19F81AA10016D8F8 /* SyncFragmentTests.swift */; };
-		724F58991A083725003A95A3 /* TransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C9AF401A00201300D3FA09 /* TransactionTests.swift */; };
-		724F589A1A083725003A95A3 /* TreeChangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561F19F81AA10016D8F8 /* TreeChangeTests.swift */; };
-		72A10BF21A38B9CC00FE7CEE /* ScopePauseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A10BF11A38B9CC00FE7CEE /* ScopePauseTests.swift */; };
 		72EFCC3919F9B6700054BC18 /* test.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 72EFCC3819F9B6700054BC18 /* test.jpg */; };
 /* End PBXBuildFile section */
 
@@ -554,14 +543,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				7225568319F81B430016D8F8 /* Session.swift in Sources */,
-				724F589A1A083725003A95A3 /* TreeChangeTests.swift in Sources */,
 				7225568919F81B430016D8F8 /* Transport.swift in Sources */,
 				72126CB01A3121410006CD29 /* Signal.swift in Sources */,
-				724F58911A083725003A95A3 /* ChangeSetTests.swift in Sources */,
-				724F58941A083725003A95A3 /* ModelTests.swift in Sources */,
-				724F58991A083725003A95A3 /* TransactionTests.swift in Sources */,
 				7225568219F81B430016D8F8 /* ScopeSyncMessage.swift in Sources */,
-				72A10BF21A38B9CC00FE7CEE /* ScopePauseTests.swift in Sources */,
 				7225568119F81B430016D8F8 /* ScopeStateMessage.swift in Sources */,
 				723A39801A07F8E900FD47A0 /* ScopeFetchReplyMessage.swift in Sources */,
 				7225568419F81B430016D8F8 /* SessionCreateMessage.swift in Sources */,
@@ -571,27 +555,21 @@
 				7225567B19F81B430016D8F8 /* ModelObject.swift in Sources */,
 				7225568019F81B430016D8F8 /* ScopeFetchMessage.swift in Sources */,
 				7225567919F81B430016D8F8 /* Logging.swift in Sources */,
-				724F58971A083725003A95A3 /* StateMessageTests.swift in Sources */,
 				7225567419F81B430016D8F8 /* Client.swift in Sources */,
 				7225568519F81B430016D8F8 /* SessionCreateReplyMessage.swift in Sources */,
 				723A39811A07F8E900FD47A0 /* ScopeSyncReplyMessage.swift in Sources */,
+				722F9AC41A43893A00A2369A /* ChangeSetTests.swift in Sources */,
 				7225568719F81B430016D8F8 /* ChangeSet.swift in Sources */,
 				7225567D19F81B430016D8F8 /* PingMessage.swift in Sources */,
 				7225567E19F81B430016D8F8 /* ReplyMessage.swift in Sources */,
-				724F58931A083725003A95A3 /* ImmediatePropertyListeners.swift in Sources */,
-				7220026C1A08362B00C6DCDD /* ChangeSetQueueTests.swift in Sources */,
 				7225567F19F81B430016D8F8 /* Scope.swift in Sources */,
 				7225567819F81B430016D8F8 /* Functions.swift in Sources */,
 				7225567C19F81B430016D8F8 /* ModelValue.swift in Sources */,
-				724F58961A083725003A95A3 /* ScopeTests.swift in Sources */,
 				7225562919F81AA10016D8F8 /* TestModel.swift in Sources */,
 				7225562819F81AA10016D8F8 /* TestHelpers.swift in Sources */,
 				7225568619F81B430016D8F8 /* SyncFragment.swift in Sources */,
 				7225568819F81B430016D8F8 /* ChangeSetQueue.swift in Sources */,
-				724F58921A083725003A95A3 /* DependencyTests.swift in Sources */,
 				7225568A19F81B430016D8F8 /* WebsocketTransportAdapter.swift in Sources */,
-				724F58981A083725003A95A3 /* SyncFragmentTests.swift in Sources */,
-				724F58951A083725003A95A3 /* PropertyListenerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Jetstream.xcodeproj/project.pbxproj
+++ b/Jetstream.xcodeproj/project.pbxproj
@@ -60,6 +60,17 @@
 		7225568919F81B430016D8F8 /* Transport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225565B19F81B040016D8F8 /* Transport.swift */; };
 		7225568A19F81B430016D8F8 /* WebsocketTransportAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225565C19F81B040016D8F8 /* WebsocketTransportAdapter.swift */; };
 		722F9AC41A43893A00A2369A /* ChangeSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561E19F81AA10016D8F8 /* ChangeSetTests.swift */; };
+		722F9AC71A4394F300A2369A /* ChangeSetQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7216634E19F83FD3007704D2 /* ChangeSetQueueTests.swift */; };
+		722F9AC81A4394F300A2369A /* DependencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561419F81AA10016D8F8 /* DependencyTests.swift */; };
+		722F9AC91A4394F300A2369A /* ImmediatePropertyListeners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561619F81AA10016D8F8 /* ImmediatePropertyListeners.swift */; };
+		722F9ACA1A4394F300A2369A /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561719F81AA10016D8F8 /* ModelTests.swift */; };
+		722F9ACB1A4394F300A2369A /* PropertyListenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561819F81AA10016D8F8 /* PropertyListenerTests.swift */; };
+		722F9ACC1A4394F300A2369A /* ScopePauseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A10BF11A38B9CC00FE7CEE /* ScopePauseTests.swift */; };
+		722F9ACD1A4394F300A2369A /* ScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561919F81AA10016D8F8 /* ScopeTests.swift */; };
+		722F9ACE1A4394F300A2369A /* StateMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561A19F81AA10016D8F8 /* StateMessageTests.swift */; };
+		722F9ACF1A4394F300A2369A /* SyncFragmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561B19F81AA10016D8F8 /* SyncFragmentTests.swift */; };
+		722F9AD01A4394F300A2369A /* TransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72C9AF401A00201300D3FA09 /* TransactionTests.swift */; };
+		722F9AD11A4394F300A2369A /* TreeChangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7225561F19F81AA10016D8F8 /* TreeChangeTests.swift */; };
 		723A39791A042A1E00FD47A0 /* ScopeSyncReplyMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723A39781A042A1E00FD47A0 /* ScopeSyncReplyMessage.swift */; };
 		723A397F1A0446CB00FD47A0 /* ScopeFetchReplyMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723A397E1A0446CB00FD47A0 /* ScopeFetchReplyMessage.swift */; };
 		723A39801A07F8E900FD47A0 /* ScopeFetchReplyMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723A397E1A0446CB00FD47A0 /* ScopeFetchReplyMessage.swift */; };
@@ -543,30 +554,41 @@
 			buildActionMask = 2147483647;
 			files = (
 				7225568319F81B430016D8F8 /* Session.swift in Sources */,
+				722F9ACD1A4394F300A2369A /* ScopeTests.swift in Sources */,
 				7225568919F81B430016D8F8 /* Transport.swift in Sources */,
 				72126CB01A3121410006CD29 /* Signal.swift in Sources */,
 				7225568219F81B430016D8F8 /* ScopeSyncMessage.swift in Sources */,
 				7225568119F81B430016D8F8 /* ScopeStateMessage.swift in Sources */,
+				722F9ACF1A4394F300A2369A /* SyncFragmentTests.swift in Sources */,
 				723A39801A07F8E900FD47A0 /* ScopeFetchReplyMessage.swift in Sources */,
+				722F9AD01A4394F300A2369A /* TransactionTests.swift in Sources */,
 				7225568419F81B430016D8F8 /* SessionCreateMessage.swift in Sources */,
 				7225567619F81B430016D8F8 /* Constants.swift in Sources */,
 				7225567A19F81B430016D8F8 /* NetworkMessage.swift in Sources */,
+				722F9ACB1A4394F300A2369A /* PropertyListenerTests.swift in Sources */,
 				72126CAF1A3121410006CD29 /* WebSocket.swift in Sources */,
 				7225567B19F81B430016D8F8 /* ModelObject.swift in Sources */,
 				7225568019F81B430016D8F8 /* ScopeFetchMessage.swift in Sources */,
+				722F9ACC1A4394F300A2369A /* ScopePauseTests.swift in Sources */,
 				7225567919F81B430016D8F8 /* Logging.swift in Sources */,
 				7225567419F81B430016D8F8 /* Client.swift in Sources */,
 				7225568519F81B430016D8F8 /* SessionCreateReplyMessage.swift in Sources */,
+				722F9ACA1A4394F300A2369A /* ModelTests.swift in Sources */,
 				723A39811A07F8E900FD47A0 /* ScopeSyncReplyMessage.swift in Sources */,
+				722F9AD11A4394F300A2369A /* TreeChangeTests.swift in Sources */,
 				722F9AC41A43893A00A2369A /* ChangeSetTests.swift in Sources */,
 				7225568719F81B430016D8F8 /* ChangeSet.swift in Sources */,
+				722F9AC91A4394F300A2369A /* ImmediatePropertyListeners.swift in Sources */,
 				7225567D19F81B430016D8F8 /* PingMessage.swift in Sources */,
 				7225567E19F81B430016D8F8 /* ReplyMessage.swift in Sources */,
+				722F9AC81A4394F300A2369A /* DependencyTests.swift in Sources */,
 				7225567F19F81B430016D8F8 /* Scope.swift in Sources */,
 				7225567819F81B430016D8F8 /* Functions.swift in Sources */,
 				7225567C19F81B430016D8F8 /* ModelValue.swift in Sources */,
 				7225562919F81AA10016D8F8 /* TestModel.swift in Sources */,
 				7225562819F81AA10016D8F8 /* TestHelpers.swift in Sources */,
+				722F9ACE1A4394F300A2369A /* StateMessageTests.swift in Sources */,
+				722F9AC71A4394F300A2369A /* ChangeSetQueueTests.swift in Sources */,
 				7225568619F81B430016D8F8 /* SyncFragment.swift in Sources */,
 				7225568819F81B430016D8F8 /* ChangeSetQueue.swift in Sources */,
 				7225568A19F81B430016D8F8 /* WebsocketTransportAdapter.swift in Sources */,

--- a/Jetstream/ModelObject.swift
+++ b/Jetstream/ModelObject.swift
@@ -436,11 +436,11 @@ public class ModelObject: NSObject, Observable {
     /// :param: callback The closure that gets executed every time the collection adds an element. Set the type of the element
     /// in the callback to the appropriate type of the collection.
     /// :returns: A function that cancels the observation when invoked.
-    public func observeCollectionAdd<T>(listener: AnyObject, key: String, callback: (element: T) -> Void) -> CancelObserver {
+    public func observeCollectionAdd<T>(observer: AnyObject, key: String, callback: (element: T) -> Void) -> CancelObserver {
         assert(properties[key] != nil, "no property found for key '\(key)'")
         assert(properties[key]!.valueType == ModelValueType.Array, "property '\(key)' is not an Array")
         
-        let listener = onModelAddedToCollection.listen(listener) { (key, element, atIndex) -> Void in
+        let listener = onModelAddedToCollection.listen(observer) { (key, element, atIndex) -> Void in
             if let definiteElement = element as? T {
                 callback(element: element as T)
             }
@@ -522,12 +522,14 @@ public class ModelObject: NSObject, Observable {
     ///
     /// :param: listener The listener to remove.
     public func removeObservers(listener: AnyObject) {
+        onPropertyChange.removeListener(listener)
         onModelAddedToCollection.removeListener(listener)
         onModelRemovedFromCollection.removeListener(listener)
         onDetachedFromScope.removeListener(listener)
         onAttachToScope.removeListener(listener)
         onAddedParent.removeListener(listener)
         onRemovedParent.removeListener(listener)
+        onTreeChange.removeListener(listener)
     }
     
     /// Removes the ModelObject from its scope.

--- a/Jetstream/Scope.swift
+++ b/Jetstream/Scope.swift
@@ -53,6 +53,7 @@ import Foundation
     
     var syncFragmentLookup = [NSUUID: SyncFragment]()
     var syncFragments = [SyncFragment]()
+    var removedModelObjects = [ModelObject]()
     var modelObjects = [ModelObject]()
     var modelHash = [NSUUID: ModelObject]()
     var applyingRemote = false
@@ -80,6 +81,7 @@ import Foundation
         let fragments = syncFragments
         syncFragments.removeAll(keepCapacity: false)
         syncFragmentLookup.removeAll(keepCapacity: false)
+        removedModelObjects.removeAll(keepCapacity: false)
         return fragments.filter { (fragment) -> Bool in
             // Filter out any empty change fragments
             if fragment.type == .Change &&
@@ -191,8 +193,12 @@ import Foundation
         }
         
         if modelObject.parents.count > 0 {
-            if !applyingRemote {
-                self.syncFragmentWithType(.Add, modelObject: modelObject)
+            if let index = find(removedModelObjects, modelObject) {
+                var removedModelObjects = [ModelObject]()
+            } else {
+                if !applyingRemote {
+                    self.syncFragmentWithType(.Add, modelObject: modelObject)
+                }
             }
         }
     }
@@ -200,6 +206,7 @@ import Foundation
     func removeModelObject(modelObject: ModelObject) {
         modelObjects = modelObjects.filter { $0 != modelObject }
         modelHash.removeValueForKey(modelObject.uuid)
+        removedModelObjects.append(modelObject)
         modelObject.onPropertyChange.removeListener(self)
         modelObject.onDetachedFromScope.removeListener(self)
         if let fragment = syncFragmentLookup[modelObject.uuid] {

--- a/Jetstream/Scope.swift
+++ b/Jetstream/Scope.swift
@@ -194,11 +194,9 @@ import Foundation
         
         if modelObject.parents.count > 0 {
             if let index = find(removedModelObjects, modelObject) {
-                var removedModelObjects = [ModelObject]()
-            } else {
-                if !applyingRemote {
-                    self.syncFragmentWithType(.Add, modelObject: modelObject)
-                }
+                removedModelObjects.removeAtIndex(index)
+            } else if !applyingRemote {
+                self.syncFragmentWithType(.Add, modelObject: modelObject)
             }
         }
     }

--- a/JetstreamTests/ChangeSetTests.swift
+++ b/JetstreamTests/ChangeSetTests.swift
@@ -81,4 +81,38 @@ class ChangeSetTests: XCTestCase {
         XCTAssert(root.childModel == child, "Change set reverted")
         XCTAssertEqual(scope.modelObjects.count, 2 , "Scope knows correct models")
     }
+    
+    func testArrayReversal() {
+        root.array.append(child)
+        var changeSet = ChangeSet(syncFragments: scope.getAndClearSyncFragments(), atomic: false, scope: scope)
+        XCTAssertEqual(changeSet.syncFragments.count, 2, "Correct number of sync fragments")
+        
+        
+        changeSet.revertOnScope(scope)
+        
+        XCTAssertEqual(root.array.count, 0, "Change set reverted")
+        XCTAssertEqual(scope.modelObjects.count, 1 , "Scope knows correct models")
+    }
+    
+    func testMovingChildModel() {
+        root.childModel = child
+        var changeSet = ChangeSet(syncFragments: scope.getAndClearSyncFragments(), atomic: false, scope: scope)
+        XCTAssertEqual(changeSet.syncFragments.count, 2, "Correct number of sync fragments")
+        
+        root.childModel = nil
+        root.childModel2 = child
+        
+        changeSet = ChangeSet(syncFragments: scope.getAndClearSyncFragments(), atomic: false, scope: scope)
+        XCTAssertEqual(changeSet.syncFragments.count, 1, "No add fragment created")
+        
+        root.childModel2 = nil
+        
+        changeSet = ChangeSet(syncFragments: scope.getAndClearSyncFragments(), atomic: false, scope: scope)
+        XCTAssertEqual(changeSet.syncFragments.count, 1, "No add fragment created")
+        
+        root.childModel = child
+        
+        changeSet = ChangeSet(syncFragments: scope.getAndClearSyncFragments(), atomic: false, scope: scope)
+        XCTAssertEqual(changeSet.syncFragments.count, 2, "Add fragment created")
+    }
 }


### PR DESCRIPTION
Keep removed model objects around until a full change set is collected to ensure that we don't create superfluous add fragments
