### PR TITLE
Fixes HasNewValuePropertyConstraints

### DIFF
--- a/Jetstream/Constraint.swift
+++ b/Jetstream/Constraint.swift
@@ -133,11 +133,7 @@ public class Constraint {
                             if let propertyInfo = propertyInfos[constraintKey] {
                                 // Check value matches constraint
                                 if let hasNewValueConstraintValue = constraintValue as? HasNewValuePropertyConstraint {
-                                    // Apply a simple check to make sure this change has a new model value
-                                    let fragmentModelValue = convertAnyObjectToModelValue(value, propertyInfo.valueType)
-                                    if value !== NSNull() && fragmentModelValue == nil {
-                                        return false
-                                    }
+                                    // Allow all cases where constraintValue is HasNewValuePropertyConstraint
                                 } else if let arrayConstraintValue = constraintValue as? ArrayPropertyConstraint {
                                     // Apply an array constraint value
                                     if let array = value as? [AnyObject] {

--- a/JetstreamTests/ConstraintTests.swift
+++ b/JetstreamTests/ConstraintTests.swift
@@ -75,16 +75,19 @@ class ConstraintTests: XCTestCase {
             "type": "change",
             "uuid": NSUUID().UUIDString,
             "clsName": "TestModel",
-            "properties": ["string": "set new value", "integer": NSNull()]
+            "properties": ["string": "set new value", "integer": NSNull(), "childModel":"11111-11111-11111-11111-1111"]
         ]
         var fragment = SyncFragment.unserialize(json)
         
         let constraint = Constraint(type: .Change, clsName: "TestModel", properties: [
             "string": HasNewValuePropertyConstraint(),
-            "integer": HasNewValuePropertyConstraint()
+            "integer": HasNewValuePropertyConstraint(),
+            "childModel": HasNewValuePropertyConstraint()
         ])
         XCTAssertTrue(constraint.matches(fragment!), "Constraint should match fragment")
     }
+    
+
     
     func testSimpleAddMatching() {
         var json: [String: AnyObject] = [


### PR DESCRIPTION
HasNewValuePropertyConstraints shouldn't try to use convertAnyObjectToModelValue as ModelObjects are represented as strings in a SyncFragment and can't be unserialzed without access to scope.
