### PR TITLE
Rename NetworkMessage unserialize to unserializeDictionary.

### DIFF
--- a/Jetstream/NetworkMessage.swift
+++ b/Jetstream/NetworkMessage.swift
@@ -46,7 +46,7 @@ public class NetworkMessage {
         return ["type": type, "index": index]
     }
     
-    public class func unserialize(dictionary: [String: AnyObject]) -> NetworkMessage? {
+    public class func unserializeDictionary(dictionary: [String: AnyObject]) -> NetworkMessage? {
         let type: AnyObject? = dictionary["type"]
         if let definiteType = type as? String {
             switch definiteType {

--- a/Jetstream/PingMessage.swift
+++ b/Jetstream/PingMessage.swift
@@ -57,7 +57,7 @@ public class PingMessage: NetworkMessage {
         return dictionary
     }
 
-    public override class func unserialize(dictionary: [String: AnyObject]) -> NetworkMessage? {
+    public class func unserialize(dictionary: [String: AnyObject]) -> NetworkMessage? {
         var index = dictionary["index"] as? UInt
         var ack = dictionary["ack"] as? UInt
         var resendMissing = dictionary["resendMissing"] as? Bool

--- a/Jetstream/ScopeFetchReplyMessage.swift
+++ b/Jetstream/ScopeFetchReplyMessage.swift
@@ -46,7 +46,7 @@ class ScopeFetchReplyMessage: ReplyMessage {
         assertionFailure("ScopeSyncReplyMessage cannot serialize itself")
     }
     
-    override class func unserialize(dictionary: [String: AnyObject]) -> NetworkMessage? {
+    class func unserialize(dictionary: [String: AnyObject]) -> NetworkMessage? {
         var index = dictionary["index"] as? UInt
         var replyTo = dictionary["replyTo"] as? UInt
         var scopeIndex = dictionary["scopeIndex"] as? UInt

--- a/Jetstream/ScopeStateMessage.swift
+++ b/Jetstream/ScopeStateMessage.swift
@@ -59,7 +59,7 @@ class ScopeStateMessage: NetworkMessage {
         return dictionary
     }
     
-    override class func unserialize(dictionary: [String: AnyObject]) -> NetworkMessage? {
+    class func unserialize(dictionary: [String: AnyObject]) -> NetworkMessage? {
         var index: UInt?
         var scopeIndex: UInt?
         var rootUUID: NSUUID?

--- a/Jetstream/ScopeSyncMessage.swift
+++ b/Jetstream/ScopeSyncMessage.swift
@@ -70,7 +70,7 @@ class ScopeSyncMessage: NetworkMessage {
         return dictionary
     }
     
-    override class func unserialize(dictionary: [String: AnyObject]) -> NetworkMessage? {
+    class func unserialize(dictionary: [String: AnyObject]) -> NetworkMessage? {
         var index: UInt?
         var scopeIndex: UInt?
         var syncFragments: [SyncFragment]?

--- a/Jetstream/ScopeSyncReplyMessage.swift
+++ b/Jetstream/ScopeSyncReplyMessage.swift
@@ -51,7 +51,7 @@ class ScopeSyncReplyMessage: ReplyMessage {
         assertionFailure("ScopeSyncReplyMessage cannot serialize itself")
     }
     
-    override class func unserialize(dictionary: [String: AnyObject]) -> NetworkMessage? {
+    class func unserialize(dictionary: [String: AnyObject]) -> NetworkMessage? {
         var index = dictionary["index"] as? UInt
         var replyTo = dictionary["replyTo"] as? UInt
         var serializedFragmentReplies = dictionary["fragmentReplies"] as? [[String: AnyObject]]

--- a/Jetstream/SessionCreateMessage.swift
+++ b/Jetstream/SessionCreateMessage.swift
@@ -57,7 +57,7 @@ class SessionCreateMessage: NetworkMessage {
         return dictionary
     }
     
-    override class func unserialize(dictionary: [String: AnyObject]) -> NetworkMessage? {
+    class func unserialize(dictionary: [String: AnyObject]) -> NetworkMessage? {
         var params = dictionary["params"] as? [String: AnyObject]
         var version = dictionary["version"] as? String
         

--- a/Jetstream/SessionCreateReplyMessage.swift
+++ b/Jetstream/SessionCreateReplyMessage.swift
@@ -41,7 +41,7 @@ class SessionCreateReplyMessage: NetworkMessage {
         super.init(index: index)
     }
     
-    override class func unserialize(dictionary: [String: AnyObject]) -> NetworkMessage? {
+    class func unserialize(dictionary: [String: AnyObject]) -> NetworkMessage? {
         var index = dictionary["index"] as? UInt
         var sessionToken = dictionary["sessionToken"] as? String
         

--- a/Jetstream/WebsocketTransportAdapter.swift
+++ b/Jetstream/WebsocketTransportAdapter.swift
@@ -179,7 +179,7 @@ public class WebSocketTransportAdapter: NSObject, TransportAdapter, WebSocketDel
     
     func tryReadSerializedMessage(object: AnyObject) {
         if let dictionary = object as? [String: AnyObject] {
-            let message = NetworkMessage.unserialize(dictionary)
+            let message = NetworkMessage.unserializeDictionary(dictionary)
             if message != nil {
                 switch message! {
                 case let pingMessage as PingMessage:

--- a/JetstreamTests/ScopePauseTests.swift
+++ b/JetstreamTests/ScopePauseTests.swift
@@ -70,7 +70,7 @@ class ScopePauseTest: XCTestCase {
             ]
         ]
         
-        firstMessage = NetworkMessage.unserialize(json) as ScopeStateMessage
+        firstMessage = NetworkMessage.unserializeDictionary(json) as ScopeStateMessage
         client.receivedMessage(firstMessage)
     }
     
@@ -94,7 +94,7 @@ class ScopePauseTest: XCTestCase {
         ]
         
         root.scope?.pauseIncomingMessages()
-        client.receivedMessage(NetworkMessage.unserialize(json)!)
+        client.receivedMessage(NetworkMessage.unserializeDictionary(json)!)
         XCTAssertEqual(root.string!, "set correctly", "Property not yet changed")
 
         root.scope?.resumeIncomingMessages()
@@ -117,7 +117,7 @@ class ScopePauseTest: XCTestCase {
                 ]
             ]
         ]
-        client.receivedMessage(NetworkMessage.unserialize(json)!)
+        client.receivedMessage(NetworkMessage.unserializeDictionary(json)!)
         
         json = [
             "type": "ScopeSync",
@@ -132,7 +132,7 @@ class ScopePauseTest: XCTestCase {
                 ]
             ]
         ]
-        client.receivedMessage(NetworkMessage.unserialize(json)!)
+        client.receivedMessage(NetworkMessage.unserializeDictionary(json)!)
         
         XCTAssertEqual(root.string!, "set correctly", "Property not yet changed")
         XCTAssertEqual(root.integer, 10, "Property not yet changed")

--- a/JetstreamTests/StateMessageTests.swift
+++ b/JetstreamTests/StateMessageTests.swift
@@ -71,7 +71,7 @@ class StateMessageTests: XCTestCase {
             ]
         ]
         
-        firstMessage = NetworkMessage.unserialize(json) as ScopeStateMessage
+        firstMessage = NetworkMessage.unserializeDictionary(json) as ScopeStateMessage
         client.receivedMessage(firstMessage)
         
         XCTAssertEqual(root.uuid, uuid, "Message applied")
@@ -117,7 +117,7 @@ class StateMessageTests: XCTestCase {
             ]
         ]
 
-        client.receivedMessage(NetworkMessage.unserialize(json)!)
+        client.receivedMessage(NetworkMessage.unserializeDictionary(json)!)
 
         XCTAssertNil(root.childModel, "Removed child")
         XCTAssertEqual(scope.modelObjects.count, 1, "Correct number of objects in scope")
@@ -150,7 +150,7 @@ class StateMessageTests: XCTestCase {
         
         XCTAssert(root.childModel != nil, "Child model moved")
         
-        client.receivedMessage(NetworkMessage.unserialize(json)!)
+        client.receivedMessage(NetworkMessage.unserializeDictionary(json)!)
         
         XCTAssert(root.childModel == nil, "Child model moved")
         XCTAssert(root.childModel2 != nil, "Child model moved")
@@ -195,7 +195,7 @@ class StateMessageTests: XCTestCase {
             ]
         ]
         
-        client.receivedMessage(NetworkMessage.unserialize(json)!)
+        client.receivedMessage(NetworkMessage.unserializeDictionary(json)!)
         
         XCTAssertEqual(root.childModel2!.uuid, childUUID, "Child model added")
         XCTAssertEqual(root.childModel2!.childModel!.uuid, childUUID2, "Child model added")
@@ -226,7 +226,7 @@ class StateMessageTests: XCTestCase {
                 ]
             ]
         ]
-        client.receivedMessage(NetworkMessage.unserialize(json)!)
+        client.receivedMessage(NetworkMessage.unserializeDictionary(json)!)
         XCTAssertEqual(root.testType, TestType.Active, "Applied enum")
        
         var comp: [CGFloat] = Array(count: 4, repeatedValue: 0);


### PR DESCRIPTION
This removes Sub-class overrides on the unserialize function that causes the Swift optimizer to go crazy
